### PR TITLE
Extra TRACE logs (especially related to gas)

### DIFF
--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -800,10 +800,11 @@ func (context *runtimeContext) ExecuteAsyncCall(address []byte, data []byte, val
 	gasToLock := uint64(0)
 	if context.HasCallbackMethod() {
 		gasToLock = metering.ComputeGasLockedForAsync()
-		log.Trace("ExecuteAsyncCall", "gasToLock", gasToLock)
+		logRuntime.Trace("ExecuteAsyncCall", "gasToLock", gasToLock)
 
 		err = metering.UseGasBounded(gasToLock)
 		if err != nil {
+			logRuntime.Trace("ExecuteAsyncCall: cannot lock gas", "err", err)
 			return err
 		}
 	}

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -800,6 +800,8 @@ func (context *runtimeContext) ExecuteAsyncCall(address []byte, data []byte, val
 	gasToLock := uint64(0)
 	if context.HasCallbackMethod() {
 		gasToLock = metering.ComputeGasLockedForAsync()
+		log.Trace("ExecuteAsyncCall", "gasToLock", gasToLock)
+
 		err = metering.UseGasBounded(gasToLock)
 		if err != nil {
 			return err

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -347,8 +347,7 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 		"len(code)", len(input.ContractCode),
 		"metadata", input.ContractCodeMetadata,
 		"gasProvided", input.GasProvided,
-		"gasLocked", input.GasLocked,
-	)
+		"gasLocked", input.GasLocked)
 
 	done := make(chan struct{})
 	errChan := make(chan error, 1)
@@ -366,8 +365,7 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 		log.Trace("RunSmartContractCreate end",
 			"returnCode", vmOutput.ReturnCode,
 			"returnMessage", vmOutput.ReturnMessage,
-			"gasRemaining", vmOutput.GasRemaining,
-		)
+			"gasRemaining", vmOutput.GasRemaining)
 
 		close(done)
 	}()
@@ -401,8 +399,7 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 	log.Trace("RunSmartContractCall begin",
 		"function", input.Function,
 		"gasProvided", input.GasProvided,
-		"gasLocked", input.GasLocked,
-	)
+		"gasLocked", input.GasLocked)
 
 	done := make(chan struct{})
 	errChan := make(chan error, 1)
@@ -426,8 +423,7 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 			"function", input.Function,
 			"returnCode", vmOutput.ReturnCode,
 			"returnMessage", vmOutput.ReturnMessage,
-			"gasRemaining", vmOutput.GasRemaining,
-		)
+			"gasRemaining", vmOutput.GasRemaining)
 
 		close(done)
 	}()

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -322,7 +322,12 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
 	defer cancel()
 
-	log.Trace("RunSmartContractCreate begin", "len(code)", len(input.ContractCode), "metadata", input.ContractCodeMetadata)
+	log.Trace("RunSmartContractCreate begin",
+		"len(code)", len(input.ContractCode),
+		"metadata", input.ContractCodeMetadata,
+		"gasProvided", input.GasProvided,
+		"gasLocked", input.GasLocked,
+	)
 
 	done := make(chan struct{})
 	errChan := make(chan error, 1)
@@ -336,6 +341,13 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 		}()
 
 		vmOutput = host.doRunSmartContractCreate(input)
+
+		log.Trace("RunSmartContractCreate end",
+			"returnCode", vmOutput.ReturnCode,
+			"returnMessage", vmOutput.ReturnMessage,
+			"gasRemaining", vmOutput.GasRemaining,
+		)
+
 		close(done)
 	}()
 
@@ -361,7 +373,11 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
 	defer cancel()
 
-	log.Trace("RunSmartContractCall begin", "function", input.Function)
+	log.Trace("RunSmartContractCall begin",
+		"function", input.Function,
+		"gasProvided", input.GasProvided,
+		"gasLocked", input.GasLocked,
+	)
 
 	done := make(chan struct{})
 	errChan := make(chan error, 1)
@@ -380,6 +396,13 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 		} else {
 			vmOutput = host.doRunSmartContractCall(input)
 		}
+
+		log.Trace("RunSmartContractCall end",
+			"function", input.Function,
+			"returnCode", vmOutput.ReturnCode,
+			"returnMessage", vmOutput.ReturnMessage,
+			"gasRemaining", vmOutput.GasRemaining,
+		)
 
 		close(done)
 	}()

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -183,7 +183,9 @@ func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfo
 		"caller", destinationCallInput.CallerAddr,
 		"dest", destinationCallInput.RecipientAddr,
 		"func", destinationCallInput.Function,
-		"args", destinationCallInput.Arguments)
+		"args", destinationCallInput.Arguments,
+		"gas provided", destinationCallInput.GasProvided,
+		"gas locked", destinationCallInput.GasLocked)
 
 	destinationVMOutput, _, err := host.ExecuteOnDestContext(destinationCallInput)
 	if destinationVMOutput != nil {
@@ -191,7 +193,8 @@ func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfo
 			"retCode", destinationVMOutput.ReturnCode,
 			"message", destinationVMOutput.ReturnMessage,
 			"data", destinationVMOutput.ReturnData,
-			"error", err)
+			"error", err,
+			"gas remaining", destinationVMOutput.GasRemaining)
 	}
 
 	return destinationCallInput, destinationVMOutput, err
@@ -222,7 +225,9 @@ func (host *vmHost) executeSyncCallbackCall(
 		"caller", callbackCallInput.CallerAddr,
 		"dest", callbackCallInput.RecipientAddr,
 		"func", callbackCallInput.Function,
-		"args", callbackCallInput.Arguments)
+		"args", callbackCallInput.Arguments,
+		"gas provided", callbackCallInput.GasProvided,
+		"gas locked", callbackCallInput.GasLocked)
 
 	// Restore gas locked while still on the caller instance; otherwise, the
 	// locked gas will appear to have been used twice by the caller instance.
@@ -234,7 +239,8 @@ func (host *vmHost) executeSyncCallbackCall(
 			"retCode", callbackVMOutput.ReturnCode,
 			"message", callbackVMOutput.ReturnMessage,
 			"data", callbackVMOutput.ReturnData,
-			"error", callBackErr)
+			"error", callBackErr,
+			"gas remaining", callbackVMOutput.GasRemaining)
 	}
 
 	return callbackVMOutput, callBackErr

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -193,8 +193,8 @@ func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfo
 			"retCode", destinationVMOutput.ReturnCode,
 			"message", destinationVMOutput.ReturnMessage,
 			"data", destinationVMOutput.ReturnData,
-			"error", err,
-			"gas remaining", destinationVMOutput.GasRemaining)
+			"gas remaining", destinationVMOutput.GasRemaining,
+			"error", err)
 	}
 
 	return destinationCallInput, destinationVMOutput, err

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -184,8 +184,8 @@ func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfo
 		"dest", destinationCallInput.RecipientAddr,
 		"func", destinationCallInput.Function,
 		"args", destinationCallInput.Arguments,
-		"gas provided", destinationCallInput.GasProvided,
-		"gas locked", destinationCallInput.GasLocked)
+		"gasProvided", destinationCallInput.GasProvided,
+		"gasLocked", destinationCallInput.GasLocked)
 
 	destinationVMOutput, _, err := host.ExecuteOnDestContext(destinationCallInput)
 	if destinationVMOutput != nil {
@@ -193,7 +193,7 @@ func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfo
 			"retCode", destinationVMOutput.ReturnCode,
 			"message", destinationVMOutput.ReturnMessage,
 			"data", destinationVMOutput.ReturnData,
-			"gas remaining", destinationVMOutput.GasRemaining,
+			"gasRemaining", destinationVMOutput.GasRemaining,
 			"error", err)
 	}
 
@@ -226,8 +226,8 @@ func (host *vmHost) executeSyncCallbackCall(
 		"dest", callbackCallInput.RecipientAddr,
 		"func", callbackCallInput.Function,
 		"args", callbackCallInput.Arguments,
-		"gas provided", callbackCallInput.GasProvided,
-		"gas locked", callbackCallInput.GasLocked)
+		"gasProvided", callbackCallInput.GasProvided,
+		"gasLocked", callbackCallInput.GasLocked)
 
 	// Restore gas locked while still on the caller instance; otherwise, the
 	// locked gas will appear to have been used twice by the caller instance.
@@ -240,7 +240,7 @@ func (host *vmHost) executeSyncCallbackCall(
 			"message", callbackVMOutput.ReturnMessage,
 			"data", callbackVMOutput.ReturnData,
 			"error", callBackErr,
-			"gas remaining", callbackVMOutput.GasRemaining)
+			"gasRemaining", callbackVMOutput.GasRemaining)
 	}
 
 	return callbackVMOutput, callBackErr

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -239,8 +239,8 @@ func (host *vmHost) executeSyncCallbackCall(
 			"retCode", callbackVMOutput.ReturnCode,
 			"message", callbackVMOutput.ReturnMessage,
 			"data", callbackVMOutput.ReturnData,
-			"error", callBackErr,
-			"gasRemaining", callbackVMOutput.GasRemaining)
+			"gasRemaining", callbackVMOutput.GasRemaining,
+			"error", callBackErr)
 	}
 
 	return callbackVMOutput, callBackErr


### PR DESCRIPTION
Added extra logs on log-level TRACE, mostly do print gas-related information (gas provided, gas locked, gas remaining).

These logs are very useful on local testnets (testnets started with erdpy).