### PR TITLE
Log ExecutionFailed by memory limit

### DIFF
--- a/arwen/common.go
+++ b/arwen/common.go
@@ -12,20 +12,28 @@ const ArwenVersion = "v1.4"
 type BreakpointValue uint64
 
 const (
-	// BreakpointNone signifies the lack of a breakpoint
+	// BreakpointNone means the lack of a breakpoint
 	BreakpointNone BreakpointValue = iota
 
-	// BreakpointExecutionFailed means that Wasmer must stop immediately due to failure indicated by Arwen
+	// BreakpointExecutionFailed means that Wasmer must stop immediately
+	// due to failure indicated by Arwen
 	BreakpointExecutionFailed
 
-	// BreakpointAsyncCall means that Wasmer must stop immediately so Arwen can execute an AsyncCall
+	// BreakpointAsyncCall means that Wasmer must stop immediately
+	// so the VM can execute an AsyncCall
 	BreakpointAsyncCall
 
-	// BreakpointSignalError means that Wasmer must stop immediately due to a contract-signalled error
+	// BreakpointSignalError means that Wasmer must stop immediately
+	// due to a contract-signalled error
 	BreakpointSignalError
 
-	// BreakpointOutOfGas means that Wasmer must stop immediately due to gas being exhausted
+	// BreakpointOutOfGas means that Wasmer must stop immediately
+	// due to gas being exhausted
 	BreakpointOutOfGas
+
+	// BreakpointMemoryLimit means that Wasmer must stop immediately
+	// due to over-allocation of WASM memory
+	BreakpointMemoryLimit
 )
 
 // AsyncCallExecutionMode encodes the execution modes of an AsyncCall

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -478,28 +478,17 @@ func (context *outputContext) DeployCode(input arwen.CodeDeployInput) {
 
 // CreateVMOutputInCaseOfError creates a new vmOutput with the given error set as return message.
 func (context *outputContext) CreateVMOutputInCaseOfError(err error) *vmcommon.VMOutput {
-	var message string
-
 	runtime := context.host.Runtime()
 	runtime.AddError(err, runtime.Function())
 
-	if errors.Is(err, arwen.ErrSignalError) {
-		message = context.ReturnMessage()
-	} else {
-		if len(context.outputState.ReturnMessage) > 0 {
-			// another return message was already set previously
-			message = context.outputState.ReturnMessage
-		} else {
-			message = err.Error()
-		}
-	}
-
 	returnCode := context.resolveReturnCodeFromError(err)
+	returnMessage := context.resolveReturnMessageFromError(err)
+
 	vmOutput := &vmcommon.VMOutput{
 		GasRemaining:  0,
 		GasRefund:     big.NewInt(0),
 		ReturnCode:    returnCode,
-		ReturnMessage: message,
+		ReturnMessage: returnMessage,
 	}
 
 	context.host.Metering().UpdateGasStateOnFailure(vmOutput)
@@ -516,6 +505,21 @@ func (context *outputContext) removeNonUpdatedCode() {
 			account.CodeDeployerAddress = nil
 		}
 	}
+}
+
+func (context *outputContext) resolveReturnMessageFromError(err error) string {
+	if errors.Is(err, arwen.ErrSignalError) {
+		return context.ReturnMessage()
+	}
+	if errors.Is(err, arwen.ErrMemoryLimit) {
+		return arwen.ErrExecutionFailed.Error()
+	}
+	if len(context.outputState.ReturnMessage) > 0 {
+		// another return message was already set previously
+		return context.outputState.ReturnMessage
+	}
+
+	return err.Error()
 }
 
 func (context *outputContext) resolveReturnCodeFromError(err error) vmcommon.ReturnCode {

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -512,10 +512,11 @@ func (context *outputContext) resolveReturnMessageFromError(err error) string {
 		return context.ReturnMessage()
 	}
 	if errors.Is(err, arwen.ErrMemoryLimit) {
+		// ErrMemoryLimit will still produce the 'execution failed' message.
 		return arwen.ErrExecutionFailed.Error()
 	}
 	if len(context.outputState.ReturnMessage) > 0 {
-		// another return message was already set previously
+		// Another return message was already set.
 		return context.outputState.ReturnMessage
 	}
 

--- a/arwen/errors.go
+++ b/arwen/errors.go
@@ -29,6 +29,9 @@ var ErrExecutionPanicked = errors.New("VM execution panicked")
 // ErrExecutionFailedWithTimeout signals that the execution failed with timeout
 var ErrExecutionFailedWithTimeout = errors.New("execution failed with timeout")
 
+// ErrMemoryLimit signals that too much memory was allocated by the contract
+var ErrMemoryLimit = errors.New("memory limit reached")
+
 // ErrBadBounds signals that a certain variable is out of bounds
 var ErrBadBounds = errors.New("bad bounds")
 

--- a/arwen/host/breakpoints.go
+++ b/arwen/host/breakpoints.go
@@ -35,6 +35,9 @@ func (host *vmHost) handleBreakpoint(breakpointValue arwen.BreakpointValue) erro
 	if breakpointValue == arwen.BreakpointOutOfGas {
 		return arwen.ErrNotEnoughGas
 	}
+	if breakpointValue == arwen.BreakpointMemoryLimit {
+		return arwen.ErrMemoryLimit
+	}
 
 	return arwen.ErrUnhandledRuntimeBreakpoint
 }

--- a/arwen/hosttest/execution_test.go
+++ b/arwen/hosttest/execution_test.go
@@ -3027,42 +3027,43 @@ func TestExecution_Mocked_ClearReturnData(t *testing.T) {
 var codeOpcodes []byte = test.GetTestSCCode("opcodes", "../../")
 
 func TestExecution_Opcodes_MemoryGrow(t *testing.T) {
-	maxMemGrow := uint32(math.MaxUint32)
-	maxMemGrowDelta := uint32(10)
-	argMemGrowDelta := int64(10)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, argMemGrowDelta, 10, vmcommon.Ok)
+	maxGrows := uint32(math.MaxUint32)
+	maxDelta := uint32(10)
+	argDelta := int64(10)
+	runMemGrowTest(t, maxGrows, maxDelta, argDelta, 10, vmcommon.Ok, "")
 }
 
 func TestExecution_Opcodes_MemoryGrow_Limit(t *testing.T) {
-	maxMemGrow := uint32(10)
-	maxMemGrowDelta := uint32(10)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta), int64(maxMemGrow-1), vmcommon.Ok)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta), int64(maxMemGrow), vmcommon.Ok)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta), int64(maxMemGrow+1), vmcommon.ExecutionFailed)
+	maxGrows := uint32(10)
+	maxDelta := uint32(10)
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta), int64(maxGrows-1), vmcommon.Ok, "")
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta), int64(maxGrows), vmcommon.Ok, "")
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta), int64(maxGrows+1), vmcommon.ExecutionFailed, arwen.ErrMemoryLimit.Error())
 }
 
 func TestExecution_Opcodes_MemoryGrowDelta(t *testing.T) {
-	maxMemGrow := uint32(10)
-	maxMemGrowDelta := uint32(10)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta-1), 1, vmcommon.Ok)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta), 1, vmcommon.Ok)
-	runWASMOpcodeTestMemGrow(t, maxMemGrow, maxMemGrowDelta, int64(maxMemGrowDelta+1), 1, vmcommon.ExecutionFailed)
+	maxGrows := uint32(10)
+	maxDelta := uint32(10)
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta-1), 1, vmcommon.Ok, "")
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta), 1, vmcommon.Ok, "")
+	runMemGrowTest(t, maxGrows, maxDelta, int64(maxDelta+1), 1, vmcommon.ExecutionFailed, arwen.ErrMemoryLimit.Error())
 }
 
 func BenchmarkOpcodeMemoryGrow(b *testing.B) {
-	maxMemGrow := uint32(math.MaxUint32)
-	maxMemGrowDelta := uint32(10)
-	argMemGrowDelta := int64(10)
-	runWASMOpcodeTestMemGrow(b, maxMemGrow, maxMemGrowDelta, argMemGrowDelta, int64(b.N), vmcommon.Ok)
+	maxGrows := uint32(math.MaxUint32)
+	maxDelta := uint32(10)
+	argDelta := int64(10)
+	runMemGrowTest(b, maxGrows, maxDelta, argDelta, int64(b.N), vmcommon.Ok, "")
 }
 
-func runWASMOpcodeTestMemGrow(
+func runMemGrowTest(
 	tb testing.TB,
 	maxMemGrow uint32,
 	maxMemGrowDelta uint32,
 	argMemGrowDelta int64,
 	reps int64,
 	expectedRetCode vmcommon.ReturnCode,
+	expectedRetMessage string,
 ) {
 	repsBigInt := big.NewInt(reps)
 	repsBytes := arwen.PadBytesLeft(repsBigInt.Bytes(), 8)
@@ -3086,6 +3087,7 @@ func runWASMOpcodeTestMemGrow(
 		}).
 		AndAssertResults(func(host arwen.VMHost, _ *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
 			verify.ReturnCode(expectedRetCode)
+			verify.ReturnMessage(expectedRetMessage)
 		})
 }
 


### PR DESCRIPTION
Modify Wasmer to react with a different breakpoint if execution fails due to memory overallocation. A log message will appear (`memory limit reached`) in the `VMOutput`, but the return code and return message remain `ExecutionFailed`.