### PR TITLE
Fixed test framework host setup issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tags
 wasm32-unknown-unknown
 test/contracts/**/target
 test/contracts/**/wasm/target
+
+# Mac
+**/.DS_Store

--- a/arwen/hosttest/execution_gas_test.go
+++ b/arwen/hosttest/execution_gas_test.go
@@ -6,16 +6,16 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	"github.com/ElrondNetwork/elrond-go-core/data/vm"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/ElrondNetwork/elrond-vm-common/txDataBuilder"
 	"github.com/ElrondNetwork/wasm-vm/arwen"
 	gasSchedules "github.com/ElrondNetwork/wasm-vm/arwenmandos/gasSchedules"
 	contextmock "github.com/ElrondNetwork/wasm-vm/mock/context"
 	"github.com/ElrondNetwork/wasm-vm/mock/contracts"
 	worldmock "github.com/ElrondNetwork/wasm-vm/mock/world"
 	test "github.com/ElrondNetwork/wasm-vm/testcommon"
-	"github.com/ElrondNetwork/elrond-go-core/core"
-	"github.com/ElrondNetwork/elrond-go-core/data/vm"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
-	"github.com/ElrondNetwork/elrond-vm-common/txDataBuilder"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1398,27 +1398,29 @@ func TestGasUsed_AsyncCallManaged_Mocks(t *testing.T) {
 	stopValue := uint64(100)
 	decrement := uint64(1)
 
+	tester := test.BuildMockInstanceCallTest(t).
+		WithContracts(
+			test.CreateMockContract(test.ParentAddress).
+				WithBalance(testConfig.ParentBalance).
+				WithConfig(testConfig).
+				WithMethods(contracts.GasMismatchAsyncCallParentMock, contracts.GasMismatchCallBackParentMock),
+			test.CreateMockContract(test.ChildAddress).
+				WithBalance(testConfig.ChildBalance).
+				WithConfig(testConfig).
+				WithMethods(contracts.GasMismatchAsyncCallChildMock),
+		).
+		WithSetup(func(host arwen.VMHost, world *worldmock.MockWorld) {
+			setZeroCodeCosts(host)
+			setAsyncCosts(host, testConfig.GasLockCost)
+		})
+
 	for gasLimit := startValue; gasLimit >= stopValue; gasLimit -= decrement {
-		test.BuildMockInstanceCallTest(t).
-			WithContracts(
-				test.CreateMockContract(test.ParentAddress).
-					WithBalance(testConfig.ParentBalance).
-					WithConfig(testConfig).
-					WithMethods(contracts.GasMismatchAsyncCallParentMock, contracts.GasMismatchCallBackParentMock),
-				test.CreateMockContract(test.ChildAddress).
-					WithBalance(testConfig.ChildBalance).
-					WithConfig(testConfig).
-					WithMethods(contracts.GasMismatchAsyncCallChildMock),
-			).
-			WithInput(test.CreateTestContractCallInputBuilder().
-				WithRecipientAddr(test.ParentAddress).
-				WithGasProvided(gasLimit).
-				WithFunction("gasMismatchParent").
-				Build()).
-			WithSetup(func(host arwen.VMHost, world *worldmock.MockWorld) {
-				setZeroCodeCosts(host)
-				setAsyncCosts(host, testConfig.GasLockCost)
-			}).
+
+		tester.WithInput(test.CreateTestContractCallInputBuilder().
+			WithRecipientAddr(test.ParentAddress).
+			WithGasProvided(gasLimit).
+			WithFunction("gasMismatchParent").
+			Build()).
 			AndAssertResults(func(world *worldmock.MockWorld, verify *test.VMOutputVerifier) {
 				if gasLimit > outOfGasValue {
 					verify.
@@ -1440,23 +1442,24 @@ func TestGasUsed_AsyncCallManaged(t *testing.T) {
 	gasSchedule, err := gasSchedules.LoadGasScheduleConfig(gasSchedules.GetV4())
 	require.Nil(t, err)
 
+	tester := test.BuildInstanceCallTest(t).
+		WithContracts(
+			test.CreateInstanceContract(test.ParentAddress).
+				WithCode(test.GetTestSCCode("async-call-parent-managed", "../../")).
+				WithBalance(1000),
+			test.CreateInstanceContract(test.ChildAddress).
+				WithCode(test.GetTestSCCode("async-call-child-managed", "../../")).
+				WithBalance(1000),
+		).
+		WithGasSchedule(gasSchedule)
+
 	for gasLimit := startValue; gasLimit >= stopValue; gasLimit -= decrement {
-		test.BuildInstanceCallTest(t).
-			WithContracts(
-				test.CreateInstanceContract(test.ParentAddress).
-					WithCode(test.GetTestSCCode("async-call-parent-managed", "../../")).
-					WithBalance(1000),
-				test.CreateInstanceContract(test.ChildAddress).
-					WithCode(test.GetTestSCCode("async-call-child-managed", "../../")).
-					WithBalance(1000),
-			).
-			WithInput(test.CreateTestContractCallInputBuilder().
-				WithRecipientAddr(test.ParentAddress).
-				WithFunction("foo").
-				WithGasProvided(gasLimit).
-				WithArguments(test.ChildAddress).
-				Build()).
-			WithGasSchedule(gasSchedule).
+		tester.WithInput(test.CreateTestContractCallInputBuilder().
+			WithRecipientAddr(test.ParentAddress).
+			WithFunction("foo").
+			WithGasProvided(gasLimit).
+			WithArguments(test.ChildAddress).
+			Build()).
 			AndAssertResults(func(host arwen.VMHost, stubBlockchainHook *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
 				if gasLimit > outOfGasValue {
 					verify.

--- a/testcommon/instanceSmartContractCreatorTest.go
+++ b/testcommon/instanceSmartContractCreatorTest.go
@@ -3,18 +3,20 @@ package testcommon
 import (
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/wasm-vm/arwen"
 	contextmock "github.com/ElrondNetwork/wasm-vm/mock/context"
-	"github.com/ElrondNetwork/elrond-vm-common"
 )
 
 // TestCreateTemplateConfig holds the data to build a contract creation test
 type TestCreateTemplateConfig struct {
-	t             *testing.T
-	address       []byte
-	input         *vmcommon.ContractCreateInput
-	setup         func(arwen.VMHost, *contextmock.BlockchainHookStub)
-	assertResults func(*contextmock.BlockchainHookStub, *VMOutputVerifier)
+	t                  *testing.T
+	address            []byte
+	input              *vmcommon.ContractCreateInput
+	setup              func(arwen.VMHost, *contextmock.BlockchainHookStub)
+	assertResults      func(*contextmock.BlockchainHookStub, *VMOutputVerifier)
+	host               arwen.VMHost
+	blockchainHookStub *contextmock.BlockchainHookStub
 }
 
 // BuildInstanceCreatorTest starts the building process for a contract creation test
@@ -50,15 +52,16 @@ func (callerTest *TestCreateTemplateConfig) AndAssertResults(assertResults func(
 }
 
 func (callerTest *TestCreateTemplateConfig) runTest() {
-	host, stubBlockchainHook := DefaultTestArwenForDeployment(callerTest.t, 24, callerTest.address)
+	if callerTest.host == nil {
+		callerTest.host, callerTest.blockchainHookStub = DefaultTestArwenForDeployment(callerTest.t, 24, callerTest.address)
+		callerTest.setup(callerTest.host, callerTest.blockchainHookStub)
+	}
 	defer func() {
-		host.Reset()
+		callerTest.host.Reset()
 	}()
 
-	callerTest.setup(host, stubBlockchainHook)
-
-	vmOutput, err := host.RunSmartContractCreate(callerTest.input)
+	vmOutput, err := callerTest.host.RunSmartContractCreate(callerTest.input)
 
 	verify := NewVMOutputVerifier(callerTest.t, vmOutput, err)
-	callerTest.assertResults(stubBlockchainHook, verify)
+	callerTest.assertResults(callerTest.blockchainHookStub, verify)
 }


### PR DESCRIPTION
There was an issue when preparing the `host`. 
It was reinstantiated in loops over and over again.
This wasted a lot of memory and works faster now.
(also excluded .DS_Store files with `.gitignore`)