### PR TITLE
minor fix for async with no callbacks

### DIFF
--- a/arwen/contexts/asyncLocal.go
+++ b/arwen/contexts/asyncLocal.go
@@ -3,11 +3,11 @@ package contexts
 import (
 	"math/big"
 
-	"github.com/ElrondNetwork/wasm-vm/arwen"
-	"github.com/ElrondNetwork/wasm-vm/math"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/data/vm"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/ElrondNetwork/wasm-vm/arwen"
+	"github.com/ElrondNetwork/wasm-vm/math"
 )
 
 func (context *asyncContext) executeAsyncLocalCalls() error {
@@ -190,8 +190,10 @@ func (context *asyncContext) executeSyncHalfOfBuiltinFunction(asyncCall *arwen.A
 	// further and execute the error callback of this AsyncCall.
 	if vmOutput.ReturnCode != vmcommon.Ok {
 		asyncCall.Reject()
-		callbackVMOutput, _, callbackErr := context.executeSyncCallback(asyncCall, vmOutput, 0, err)
-		context.finishAsyncLocalCallbackExecution(callbackVMOutput, callbackErr, 0)
+		if asyncCall.HasCallback() {
+			callbackVMOutput, _, callbackErr := context.executeSyncCallback(asyncCall, vmOutput, 0, err)
+			context.finishAsyncLocalCallbackExecution(callbackVMOutput, callbackErr, 0)
+		}
 	}
 
 	// The gas that remains after executing the in-shard half of the built-in

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -1004,8 +1004,8 @@ func (host *vmHost) callSCMethodAsynchronousCallBack() error {
 
 	async.SetCallbackParentCall(asyncCall)
 
-	callbackName := asyncCall.GetCallbackName()
-	if callbackName != "" {
+	if asyncCall.HasCallback() {
+		callbackName := asyncCall.GetCallbackName()
 		runtime.SetCustomCallFunction(callbackName)
 		isCallComplete, callbackErr := host.callFunctionAndExecuteAsync()
 


### PR DESCRIPTION
This was already implemented, we have tests for it, but there was an issue for callback calls in case of errors for local async calls.
Also a minor refactor to better clarify the code was done for async remote case.