### PR TITLE
attribute supports objects

### DIFF
--- a/arwenmandos/stepDumpWorld.go
+++ b/arwenmandos/stepDumpWorld.go
@@ -5,14 +5,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/wasm-vm/mandos-go/esdtconvert"
 	er "github.com/ElrondNetwork/wasm-vm/mandos-go/expression/reconstructor"
 	mjwrite "github.com/ElrondNetwork/wasm-vm/mandos-go/json/write"
 	mj "github.com/ElrondNetwork/wasm-vm/mandos-go/model"
 	oj "github.com/ElrondNetwork/wasm-vm/mandos-go/orderedjson"
 	worldmock "github.com/ElrondNetwork/wasm-vm/mock/world"
-	"github.com/ElrondNetwork/elrond-go-core/core"
-	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 const includeElrondProtectedStorage = false
@@ -99,11 +99,11 @@ func (ae *ArwenTestExecutor) convertMockAccountToMandosFormat(account *worldmock
 				})
 			}
 
-			var attributes mj.JSONBytesFromString
+			var attributes mj.JSONBytesFromTree
 			if len(mockInstance.TokenMetaData.Attributes) > 0 {
-				attributes = mj.JSONBytesFromString{
+				attributes = mj.JSONBytesFromTree{
 					Value:    mockInstance.TokenMetaData.Attributes,
-					Original: ae.exprReconstructor.Reconstruct(mockInstance.TokenMetaData.Attributes, er.NoHint),
+					Original: &oj.OJsonString{Value: ae.exprReconstructor.Reconstruct(mockInstance.TokenMetaData.Attributes, er.NoHint)},
 				}
 			}
 

--- a/mandos-go/json/parse/parseESDT.go
+++ b/mandos-go/json/parse/parseESDT.go
@@ -131,7 +131,7 @@ func (p *Parser) tryProcessESDTInstanceField(kvp *oj.OJsonKeyValuePair, targetIn
 			return false, fmt.Errorf("invalid ESDT NFT URI: %w", err)
 		}
 	case "attributes":
-		targetInstance.Attributes, err = p.processStringAsByteArray(kvp.Value)
+		targetInstance.Attributes, err = p.processSubTreeAsByteArray(kvp.Value)
 		if err != nil {
 			return false, fmt.Errorf("invalid ESDT NFT attributes: %w", err)
 		}

--- a/mandos-go/json/write/writeESDT.go
+++ b/mandos-go/json/write/writeESDT.go
@@ -97,8 +97,8 @@ func appendESDTInstanceToOJ(esdtInstance *mj.ESDTInstance, targetOj *oj.OJsonMap
 	if !esdtInstance.Uris.IsUnspecified() {
 		targetOj.Put("uri", valueListToOJ(esdtInstance.Uris))
 	}
-	if len(esdtInstance.Attributes.Original) > 0 {
-		targetOj.Put("attributes", bytesFromStringToOJ(esdtInstance.Attributes))
+	if !esdtInstance.Attributes.Unspecified {
+		targetOj.Put("attributes", bytesFromTreeToOJ(esdtInstance.Attributes))
 	}
 }
 

--- a/mandos-go/model/esdt.go
+++ b/mandos-go/model/esdt.go
@@ -15,7 +15,7 @@ type ESDTInstance struct {
 	Royalties  JSONUint64
 	Hash       JSONBytesFromString
 	Uris       JSONValueList
-	Attributes JSONBytesFromString
+	Attributes JSONBytesFromTree
 }
 
 // ESDTData models an account holding an ESDT token


### PR DESCRIPTION
Cummunity reported issue: 

> Seems like using mandos you can't specify nft attributes using the more advanced mandos syntax (https://docs.elrond.com/developers/mandos-reference/values-complex) that you can use for arguments for example.
> Would be great if this could use the same syntax :slightly_smiling_face:
> Hey Martin, I did what you recommended for the attributes field but I got this error "invalid ESDT NFT attributes : not a string value", we can't have an object in the attributes field?
> 
> ```
> "step": "setState",
>             "accounts": {
>                 "address:owner": {
>                     "nonce": "0",
>                     "balance": "0"
>                 },
>                 "address:bob": {
>                     "nonce": "5",
>                     "balance": "100",
>                     "esdt": {
>                         "str:ROTG-abcdef": {
>                             "instances": [
>                                 {
>                                     "nonce": "1",
>                                     "balance": "1",
>                                     "attributes": {
>                                         "00-id": "u16:1",
>                                         "01-element": "u8:2",
>                                         "02-body_vril": "u16:1315",
>                                         "03-hairstyle": "nested:str:Sabler Brown",
>                                         "04-eyes": "nested:str:Wise Cyclop Grey",
>                                         "05-nose": "nested:str:Blawn",
>                                         "06-mouth": "nested:str:Gimlys",
>                                         "07-background": {
>                                             "01-trait_type": "nested:str:Background",
>                                             "02-value": "nested:str:Caiamme",
>                                             "03-element": "u8:0",
>                                             "04-vril": "u16:0",
>                                             "05-metadata": "nested:str:metadata:Background/Caiamme.json"
>                                         },
>                                         "08-crown": {
>                                             "01-trait_type": "nested:str:Crown",
>                                             "02-value": "nested:str:Whisper of Tourment Rock 2",
>                                             "03-element": "u8:2",
>                                             "04-vril": "u16:540",
>                                             "05-metadata": "nested:str:metadata:Crown/Whisper of Tourment Rock 2.json"
>                                         },
>                                         "09-weapon": {
>                                             "01-trait_type": "nested:str:Weapon",
>                                             "02-value": "nested:str:Ivry's Axe Rock 2",
>                                             "03-element": "u8:2",
>                                             "04-vril": "u16:820",
>                                             "05-metadata": "nested:str:metadata:Weapon/Ivry's Axe Rock 2.json"
>                                         },
>                                         "10-armor": {
>                                             "01-trait_type": "nested:str:Armor",
>                                             "02-value": "nested:str:Sabaku Rock 1",
>                                             "03-element": "u8:2",
>                                             "04-vril": "u16:420",
>                                             "05-metadata": "nested:str:metadata:Armor/Sabaku Rock 1.json"
>                                         },
>                                         "11-metadata": "nested:str:metadata:guardianCid/1.json"
>                                     }
>                                 }
>                             ],
>                             "lastNonce": "1"
>                         },
> ```
>                         
> As you can see his example is quite complex and it would be very tedious and unreadable to bring that into a simple string :pray:

This mandos test was used as test for the fix
