### PR TITLE
wasmer2 mandos flag

### DIFF
--- a/cmd/mandostestcli/mandosTestCLI.go
+++ b/cmd/mandostestcli/mandosTestCLI.go
@@ -26,10 +26,12 @@ func resolveArgument(exeDir string, arg string) (string, bool, error) {
 
 func parseOptionFlags() *mc.RunScenarioOptions {
 	forceTraceGas := flag.Bool("force-trace-gas", false, "overrides the traceGas option in the scenarios")
+	useWasmer2 := flag.Bool("wasmer2", false, "use the wasmer2 executor")
 	flag.Parse()
 
 	return &mc.RunScenarioOptions{
 		ForceTraceGas: *forceTraceGas,
+		UseWasmer2:    *useWasmer2,
 	}
 }
 
@@ -46,7 +48,7 @@ func MandosTestCLI() {
 
 	// argument
 	args := flag.Args()
-	if len(args) != 1 {
+	if len(args) < 1 {
 		panic("One argument expected - the path to the json test or directory.")
 	}
 	jsonFilePath, isDir, err := resolveArgument(exeDir, args[0])
@@ -60,6 +62,7 @@ func MandosTestCLI() {
 	if err != nil {
 		panic("Could not instantiate Arwen VM")
 	}
+	executor.UseWasmer2 = options.UseWasmer2
 
 	// execute
 	switch {

--- a/integrationTests/json/mandosTestCommon.go
+++ b/integrationTests/json/mandosTestCommon.go
@@ -1,6 +1,7 @@
 package vmjsonintegrationtest
 
 import (
+	"flag"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	mc "github.com/ElrondNetwork/wasm-vm/mandos-go/controller"
 	"github.com/stretchr/testify/require"
 )
+
+var useWasmer2 = flag.Bool("wasmer2", false, "Test using Wasmer2")
 
 func init() {
 	_ = logger.SetLogLevel("*:NONE")
@@ -33,6 +36,7 @@ func runTestsInFolder(t *testing.T, folder string, exclusions []string) {
 	executor, err := am.NewArwenTestExecutor()
 	require.Nil(t, err)
 	defer executor.Close()
+	executor.UseWasmer2 = *useWasmer2
 
 	runner := mc.NewScenarioRunner(
 		executor,
@@ -57,6 +61,7 @@ func runSingleTestReturnError(folder string, filename string) error {
 		return err
 	}
 	defer executor.Close()
+	executor.UseWasmer2 = *useWasmer2
 
 	runner := mc.NewScenarioRunner(
 		executor,

--- a/mandos-go/controller/scenarioOne.go
+++ b/mandos-go/controller/scenarioOne.go
@@ -6,6 +6,7 @@ import (
 
 type RunScenarioOptions struct {
 	ForceTraceGas bool
+	UseWasmer2    bool
 }
 
 func applyScenarioOptions(scenario *mj.Scenario, options *RunScenarioOptions) {


### PR DESCRIPTION
Helps test the new features.

Add flag `-wasmer2` to tests and debugger.

I know an executor factory is needed, we'll do it, not now.